### PR TITLE
feat: develop achievements about shot and life

### DIFF
--- a/src/engine/AchievementManager.java
+++ b/src/engine/AchievementManager.java
@@ -25,10 +25,14 @@ public class AchievementManager {
         // Initialize predefined achievements
         achievements.put("adventure start", false);
         achievements.put("sharp shooter", false);
-        achievements.put("perfect shooter", false);
+        achievements.put("deadly accuracy", false); 
         achievements.put("lucky guy", false);
         achievements.put("unlucky guy", false);
         achievements.put("game ace", false);
+        achievements.put("soul mates", false);
+        achievements.put("aviophobia", false);
+        achievements.put("buddy fxxker", false);
+        achievements.put("pat & mat", false);
     }
 
     public Map<String, Boolean> getAchievements() {
@@ -75,18 +79,47 @@ public class AchievementManager {
     }
 
     /**
-     * Check if the requirments for sharp shooter are met
+     * Check if the requirments for achievements about accuracy and life
      */
     public void checkAchievements (GameState gameState) {
         int level = gameState.getLevel();
         int shot = gameState.getBulletsShot1() + gameState.getBulletsShot2();
-        
+        int life_1 = gameState.getLivesRemaining1p();
+        int life_2 = gameState.getLivesRemaining2p();
+        int gamemode = gameState.getMode();
         double accuracy = ((double)gameState.getShipsDestroyed() / (double)shot) * 100;
-        if (shot > 0 && accuracy >= 10 && level >= 3) {
-            markAchievementAsAchieved("sharp shooter");
-        }
-    }
 
+        //if the player play with good accuracy 
+        if (shot > 0 && accuracy >= 90.0 && level >= 3) {
+            markAchievementAsAchieved("sharp shooter");
+         }
+        
+         //Check if the players recorded perfect accuracy, if the player want to clear level 1, he has to shot 20 times at least
+        if (shot >= 20 && accuracy == 100) { 
+            markAchievementAsAchieved("deadly accuracy");
+        }
+
+        //Check if the player didn't hit enemy's ships in 1p mode
+        if (gamemode == 1 && shot > 0 && accuracy == 0) {
+            markAchievementAsAchieved("aviophobia");
+        }
+
+        //Check if two players didn't hit enemy's ships
+        if (gamemode == 2 && shot > 0 && accuracy == 0) {
+            markAchievementAsAchieved("pat & mat");
+        }
+
+        //Check if two players clear level or gameover with same lives 
+        if (gamemode == 2 && life_1 == life_2) {
+            markAchievementAsAchieved("soul mates");
+        }
+
+        //Check one player has max life but the partner doesn't have
+        if (gamemode == 2 && (life_1 - life_2 == 3 || life_2 - life_1 == 3)) {
+            markAchievementAsAchieved("buddy fxxker");
+        }
+
+    }
     /*
      * Check if the score equals to the achievement
      * 


### PR DESCRIPTION
I developed 5 achievements and added annotation about achievements' information
1. deadly accuracy (백발백중 old name perfect shooter) - the player record 100% accuracy
2. aviophobia (비행 공포증) - player didn't hit any enemy's ship and game over in 1p mode
3. pat & mat (패트와 매트) - two players didn't hit any enemy's ship and game over
4. soul mates (천생연분) - two players clear level or game over with same lives
5. buddy fxxker(폐급) - When game is over, one player has max life but the partner die